### PR TITLE
Support for Expo SDK 48

### DIFF
--- a/plugins/android/withAndroidKakaoLogin.ts
+++ b/plugins/android/withAndroidKakaoLogin.ts
@@ -93,7 +93,7 @@ const modifyProjectBuildGradle: ConfigPlugin<KakaoLoginPluginProps> = (
     AndroidConfig.BuildProperties.updateAndroidBuildProperty(
       config.modResults,
       'android.kotlinVersion',
-      props.kotlinVersion ?? '1.5.10',
+      props.kotlinVersion ?? '1.5.20',
     );
 
     return config;
@@ -113,7 +113,7 @@ const modifyProjectBuildGradle: ConfigPlugin<KakaoLoginPluginProps> = (
         /dependencies\s?{/,
         `dependencies {
           classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:${
-            props.kotlinVersion ?? '1.5.10'
+            props.kotlinVersion ?? '1.5.20'
           }'`,
       );
     }

--- a/plugins/ios/withIosKakaoLogin.ts
+++ b/plugins/ios/withIosKakaoLogin.ts
@@ -94,10 +94,10 @@ const modifyAppDelegate: ConfigPlugin = (config) => {
   const modifyContents = (contents: string): string => {
     if (!contents.includes(KAKAO_HEADER_IMPORT_STRING)) {
       contents = contents.replace(
-        '#if',
-        `
-      ${KAKAO_HEADER_IMPORT_STRING}
-      #if`,
+        "@implementation AppDelegate",
+        `${KAKAO_HEADER_IMPORT_STRING}
+
+@implementation AppDelegate`
       );
     }
 


### PR DESCRIPTION
Due to upgrade of react native to 0.71 on Expo SDK 48, AppDelegate and default Kotlin version need to be updated.

As upgrade of Android Gradle Plugin, kotlin-gradle-plugin is should be at least 1.5.20.
As update of RCTAppDelegate class, finding header pattern should be updated.