### PR TITLE
배송지 가져오기 기능 추가

### DIFF
--- a/KakaoLoginExample/src/pages/Intro.tsx
+++ b/KakaoLoginExample/src/pages/Intro.tsx
@@ -1,6 +1,6 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import React, { useState } from 'react';
-import { login, logout, getProfile as getKakaoProfile, unlink } from '@react-native-seoul/kakao-login';
+import { login, logout, getProfile as getKakaoProfile, shippingAddresses as getKakaoShippingAddresses, unlink } from '@react-native-seoul/kakao-login';
 import ResultView from './IntroView';
 
 const Intro = () => {
@@ -35,6 +35,16 @@ const Intro = () => {
     }
   };
 
+  const getShippingAddresses = async (): Promise<void> => {
+    try {
+      const shippingAddresses = await getKakaoShippingAddresses();
+
+      setResult(JSON.stringify(shippingAddresses));
+    } catch (err) {
+      console.error('signOut error', err);
+    }
+  };
+
   const unlinkKakao = async (): Promise<void> => {
     try {
       const message = await unlink();
@@ -64,6 +74,14 @@ const Intro = () => {
       >
         <Text style={styles.text}>
           프로필 조회
+        </Text>
+      </Pressable>
+      <Pressable
+        style={styles.button}
+        onPress={() => getShippingAddresses()}
+      >
+        <Text style={styles.text}>
+          배송주소록 조회
         </Text>
       </Pressable>
       <Pressable

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ react-native-web에서는 app과 다르게 restApikey, redirecturl을 code와 �
 | login                 |   restApiKeyWeb, redirectUrlWeb, codeWeb    |   Promise{KakaoOAuthWebToken} | 로그인                                                    |
 | loginWithKakaoAccount |       |      | 웹 지원 x |
 | getProfile            |    tokenWeb   |     Promise{KakaoProfile}     | 프로필 불러오기                                                                                                    |
-| shippingAddress       |    tokenWeb   |     Promise{KakaoShippingAddresses} | 배송지 정보 불러오기                                                                                                    |
+| shippingAddresses     |    tokenWeb   |     Promise{KakaoShippingAddresses} | 배송지 정보 불러오기                                                                                                    |
 | logout                |    tokenWeb   |        Promise{string}        | 로그아웃                                                                                                           |
 | unlink                |   tokenWeb    |        Promise{string}        | 연결끊기                                                                                                           |
 | getAccessToken        |       |  | 웹 지원 x

--- a/README.md
+++ b/README.md
@@ -111,11 +111,13 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
    > 템플릿에서 기본 제공되는것 이외의 키스토어에서 key hash 를 추출하기 위해서는 아래의 명령어를 사용하세요
    >
    >**글로벌 debug keystore 에서 key hash 추출**
+>
    >```
    >keytool -exportcert -alias androiddebugkey -keystore ~/.android/debug.keystore -storepass android -keypass android | openssl sha1 -binary | openssl base64
    >```
    >
    >**특정 경로의 keystore 에서 key hash 추출**
+>
    >```
    >keytool -exportcert -alias {my-app-key-alias} -keystore {your-key-path}/{my-app-key}.keystore -storepass android -keypass android | openssl sha1 -binary | openssl base64
    >```
@@ -165,6 +167,7 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
 #### EXPO (EAS Build only, SDK 41 이상)
 
 1. app.json 파일을 아래와 같이 수정합니다.
+
 ```
 {
   "expo": {
@@ -188,7 +191,6 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
 2. EAS Build 이후 `expo start --dev-client`를 이용합니다.
 
 3. (Optional) Android에서 proguard rules 등을 적용하실 경우, [Expo BuildProperties](https://docs.expo.dev/versions/latest/sdk/build-properties/) 를 참고하세요
-
 
 ## Methods
 
@@ -242,12 +244,11 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
 1.RestApiKey랑 redirectUrl을 포함한 아래 링크로 href 링크를 열어서 code를 가져옵니다
 const kakaoUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${restApiKey}&redirect_uri=${redirectUrl}&response_type=code`;
 
-redirectUrl이 http://localhost:3000 일때 아래와같이 redirectUrl에 code파라미터가 붙은 url이 들어와집니다
+redirectUrl이 <http://localhost:3000> 일때 아래와같이 redirectUrl에 code파라미터가 붙은 url이 들어와집니다
 
-http://localhost:3000/?code=Ss32OM1_yUybn5dtEQ-XT8EZfV24BKC_GIeIvFPz7_wHorYXtij9JFQcMuGtGdzxQc3Vlwopb1UAAAGCizvuCw
+<http://localhost:3000/?code=Ss32OM1_yUybn5dtEQ-XT8EZfV24BKC_GIeIvFPz7_wHorYXtij9JFQcMuGtGdzxQc3Vlwopb1UAAAGCizvuCw>
 code= 뒤쪽부분을 split해서 토큰 발급시 필요한 code를 얻을 수 있습니다
 react-native-web에서는 app과 다르게 restApikey, redirecturl을 code와 같이 직접 넣어줘야 합니다
-
 
 ## Methods (Web)
 
@@ -256,6 +257,7 @@ react-native-web에서는 app과 다르게 restApikey, redirecturl을 code와 �
 | login                 |   restApiKeyWeb, redirectUrlWeb, codeWeb    |   Promise{KakaoOAuthWebToken} | 로그인                                                    |
 | loginWithKakaoAccount |       |      | 웹 지원 x |
 | getProfile            |    tokenWeb   |     Promise{KakaoProfile}     | 프로필 불러오기                                                                                                    |
+| shippingAddress       |    tokenWeb   |     Promise{KakaoShippingAddresses} | 배송지 정보 불러오기                                                                                                    |
 | logout                |    tokenWeb   |        Promise{string}        | 로그아웃                                                                                                           |
 | unlink                |   tokenWeb    |        Promise{string}        | 연결끊기                                                                                                           |
 | getAccessToken        |       |  | 웹 지원 x

--- a/README.md
+++ b/README.md
@@ -212,6 +212,31 @@ iOS의 경우 `yarn add @react-native-seoul/kakao-login` 이후 `npx pod-install
 | `refreshTokenExpiresAt?` |  ✓  |    ✓    |   `Date`   | 리프레쉬 토큰 만료 시간, 구버전 SDK로 이미 로그인이 되어있었다면 null이 반환될 수 있습니다. |
 | `scopes`                 |  ✓  |    ✓    | `string[]` |                                   사용자로 부터 받은 권한                                   |
 
+#### 배송지 가져오기 - `shippingAddresses` => `KakaoShippingAddresses`
+
+|                          | iOS | Android |    type    |  Description   |
+| ------------------------ | :-: | :-----: | :--------: | :------------: |
+| `userId`                 |  ✓  |    ✓    |  `string`  | 사용자 Id        |
+| `needsAgreement`         |  ✓  |    ✓    |  `boolean` | 배송지 제공에 대한 사용자의 동의 필요 여부 |
+| `shippingAddresses`      |  ✓  |    ✓    |  `Array`   |  사용자가 소유한 배송지 목록  |
+
+##### 배송지 정보 (KakaoShippingAddress)
+
+|                          | iOS | Android |    type    |  Description   |
+| ------------------------ | :-: | :-----: | :--------: | :------------: |
+| `id`                 |  ✓  |    ✓    |  `string`  | 배송지 아이디        |
+| `name`         |  ✓  |    ✓    |  `string` | 배송지명 |
+| `isDefault`      |  ✓  |    ✓    |  `boolean`   |  기본 배송지 여부  |
+| `updatedAt`         |  ✓  |    ✓    |  `Date` | 마지막 배송지정보 수정시각 |
+| `type`         |  ✓  |    ✓    |  `string` | 배송지 타입(Old, New) |
+| `baseAddress`         |  ✓  |    ✓    |  `string` | 주소 검색을 통해 자동으로 입력되는 기본 주소 |
+| `detailAddress`         |  ✓  |    ✓    |  `string` | 기본 주소에 추가하는 상세 주소 |
+| `receiverName`         |  ✓  |    ✓    |  `string` | 수령인 이름 |
+| `receiverPhoneNumber1`         |  ✓  |    ✓    |  `string` | 수령인 연락처 |
+| `receiverPhoneNumber2`         |  ✓  |    ✓    |  `string` | 수령인 추가 연락처 |
+| `zoneNumber`         |  ✓  |    ✓    |  `string` | 도로명 주소 우편번호. 배송지 타입이 NEW(도로명 주소)인 경우 반드시 존재함 |
+| `zipCode`         |  ✓  |    ✓    |  `string` | 지번 주소 우편번호. 배송지 타입이 OLD(지번 주소)여도 값이 없을 수 있음 |
+
 #### React-native-web
 
 1.RestApiKey랑 redirectUrl을 포함한 아래 링크로 href 링크를 열어서 code를 가져옵니다
@@ -256,6 +281,12 @@ const getKakaoProfile = async (): Promise<void> => {
   const profile: KakaoProfile = await getProfile();
 
   setResult(JSON.stringify(profile));
+};
+
+const getKakaoShippingAddresses = async (): Promise<void> => {
+  const addresses: KakaoShippingAddresses = await shippingAddresses();
+
+  setResult(JSON.stringify(addresses));
 };
 
 const unlinkKakao = async (): Promise<void> => {

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -10,5 +10,6 @@ RCT_EXTERN_METHOD(logout:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseR
 RCT_EXTERN_METHOD(unlink:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
 RCT_EXTERN_METHOD(getProfile:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
 RCT_EXTERN_METHOD(getAccessToken:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
+RCT_EXTERN_METHOD(shippingAddresses:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
 
 @end

--- a/ios/RNKakaoLogins/RNKakaoLogins.swift
+++ b/ios/RNKakaoLogins/RNKakaoLogins.swift
@@ -194,4 +194,39 @@ class RNKakaoLogins: NSObject {
             }
         }
     }
+
+    @objc(shippingAddresses:rejecter:)
+    func shippingAddresses(_ resolve: @escaping RCTPromiseResolveBlock,
+               rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+        DispatchQueue.main.async {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss";
+
+            UserApi.shared.shippingAddresses() {(shippingAddresses, error) in
+                if let error = error {
+                    reject("RNKakaoLogins", error.localizedDescription, nil)
+                }
+                else {
+                    resolve([
+                        "userId": shippingAddresses?.userId as Any,
+                        "needsAgreement": shippingAddresses?.needsAgreement as Any,
+                        "shippingAddresses": shippingAddresses?.shippingAddresses?.map { shippingAddress in [
+                            "id": shippingAddress.id as Any,
+                            "name": shippingAddress.name as Any,
+                            "isDefault": shippingAddress.isDefault as Any,
+                            "updatedAt": dateFormatter.string(from: shippingAddress.updatedAt!) as Any,
+                            "type": shippingAddress.type?.rawValue as Any,
+                            "baseAddress": shippingAddress.baseAddress as Any,
+                            "detailAddress": shippingAddress.detailAddress as Any,
+                            "receiverName": shippingAddress.receiverName as Any,
+                            "receiverPhoneNumber1": shippingAddress.receiverPhoneNumber1 as Any,
+                            "receiverPhoneNumber2": shippingAddress.receiverPhoneNumber2 as Any,
+                            "zoneNumber": shippingAddress.zoneNumber as Any,
+                            "zipCode": shippingAddress.zipCode as Any,
+                        ]} as Any,
+                    ])
+                }
+            }
+        }
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,9 @@ const NativeKakaoLogins: KakaoLoginModuleInterface = {
   getAccessToken() {
     return RNKakaoLogins.getAccessToken();
   },
+  shippingAddresses() {
+    return RNKakaoLogins.shippingAddresses();
+  },
 };
 
 export const login = NativeKakaoLogins.login;
@@ -30,5 +33,6 @@ export const logout = NativeKakaoLogins.logout;
 export const unlink = NativeKakaoLogins.unlink;
 export const getProfile = NativeKakaoLogins.getProfile;
 export const getAccessToken = NativeKakaoLogins.getAccessToken;
+export const shippingAddresses = NativeKakaoLogins.shippingAddresses;
 
 export * from './types';

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -54,6 +54,15 @@ const WebKakaoLogins: KakaoLoginModuleInterface = {
       },
     }).then((res) => res.json());
   },
+  shippingAddresses(tokenWeb?: string) {
+    return fetch('https://kapi.kakao.com/v2/user/shipping_address', {
+      method: 'get',
+      headers: {
+        Authorization: `Bearer ${tokenWeb}`,
+        'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+      },
+    }).then((res) => res.json());
+  },
   async getAccessToken() {
     throw new Error('Web does not support `getAccessToken`');
   },
@@ -68,5 +77,6 @@ export const logout = WebKakaoLogins.logout;
 export const unlink = WebKakaoLogins.unlink;
 export const getProfile = WebKakaoLogins.getProfile;
 export const getAccessToken = WebKakaoLogins.getAccessToken;
+export const shippingAddresses = WebKakaoLogins.shippingAddresses;
 
 export * from './types';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,8 @@ export interface KakaoLoginModuleInterface {
   getAccessToken(): Promise<KakaoAccessTokenInfo>;
 
   loginWithKakaoAccount(): Promise<KakaoOAuthToken>;
+
+  shippingAddresses(): Promise<KakaoShippingAddresses>;
 }
 
 export type KakaoOAuthToken = {
@@ -80,4 +82,25 @@ export type KakaoProfileWebType = {
     profile_image: string;
     thumbnail_image: string;
   };
+};
+
+export type KakaoShippingAddresses = {
+  userId: string;
+  needsAgreement: boolean;
+  shippingAddresses: KakaoShippingAddress[];
+};
+
+export type KakaoShippingAddress = {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  updatedAt: string;
+  type: string;
+  baseAddress: string;
+  detailAddress: string;
+  receiverName: string;
+  receiverPhoneNumber1: string;
+  receiverPhoneNumber2: string;
+  zoneNumber: string;
+  zipCode: string;
 };


### PR DESCRIPTION
## Feature
- 카카오 유저의 배송지 가져오기 기능 추가
- Android, iOS Supported

#### API

```typescript
shippingAddresses() : Promise<KakaoShippingAddresses>
```

#### Model

```typescript
type KakaoShippingAddresses = {
  userId: string;
  needsAgreement: boolean;
  shippingAddresses: KakaoShippingAddress[];
};

type KakaoShippingAddress = {
  id: string;
  name: string;
  isDefault: boolean;
  updatedAt: string;
  type: string;
  baseAddress: string;
  detailAddress: string;
  receiverName: string;
  receiverPhoneNumber1: string;
  receiverPhoneNumber2: string;
  zoneNumber: string;
  zipCode: string;
};
```

#### Limited
- 사용자 동의 항목에 `shipping_address` 가 있어야 함 
- KakaoLoginExample 예제로는 테스트 불가


#### Test
- (shipping_address 정보가 추가된) 카카오앱에서 테스트 수행
- ✅ Android
- ✅ iOS

## Reference
- [Manual] 배송지 가져오기 ([iOS](https://developers.kakao.com/docs/latest/ko/kakaologin/ios#shipping-address), [Android](https://developers.kakao.com/docs/latest/ko/kakaologin/android#shipping-address))
- [Model] [UserShippingAddresses](https://github.com/crossplatformkorea/react-native-kakao-login/compare/main...iamchiwon:react-native-kakao-login:shippingAddresses)
- [Model] [ShippingAddress](https://developers.kakao.com/sdk/reference/ios/release/KakaoSDKUser/Structs/ShippingAddress.html)