### PR TITLE
fix: Kakao profile id type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,7 +33,7 @@ export type KakaoAccessTokenInfo = {
 };
 
 export type KakaoProfile = {
-  id: string;
+  id: number;
   email: string;
   name: string;
   nickname: string;


### PR DESCRIPTION
카카오 프로필 id 타입을 string 에서 number 로 수정하였습니다. 카카오에서 주는 profile의 id 값은 number 입니다.