### PR TITLE
feat: 서비스 약관 동의 내역 확인 기능 추가

### DIFF
--- a/KakaoLoginExample/src/pages/Intro.tsx
+++ b/KakaoLoginExample/src/pages/Intro.tsx
@@ -1,6 +1,6 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import React, { useState } from 'react';
-import { login, logout, getProfile as getKakaoProfile, shippingAddresses as getKakaoShippingAddresses, unlink } from '@react-native-seoul/kakao-login';
+import { login, logout, getProfile as getKakaoProfile, shippingAddresses as getKakaoShippingAddresses, serviceTerms as getKakaoServiceTerms, unlink } from '@react-native-seoul/kakao-login';
 import ResultView from './IntroView';
 
 const Intro = () => {
@@ -45,6 +45,16 @@ const Intro = () => {
     }
   };
 
+  const getServiceTerms = async (): Promise<void> => {
+    try {
+      const serviceTerms = await getKakaoServiceTerms();
+
+      setResult(JSON.stringify(serviceTerms));
+    } catch (err) {
+      console.error('serviceTerms error', err);
+    }
+  }
+
   const unlinkKakao = async (): Promise<void> => {
     try {
       const message = await unlink();
@@ -82,6 +92,14 @@ const Intro = () => {
       >
         <Text style={styles.text}>
           배송주소록 조회
+        </Text>
+      </Pressable>
+      <Pressable
+        style={styles.button}
+        onPress={() => getKakaoServiceTerms()}
+      >
+        <Text style={styles.text}>
+          서비스 약관 동의 내역 확인
         </Text>
       </Pressable>
       <Pressable

--- a/README.md
+++ b/README.md
@@ -243,6 +243,31 @@ SDK49 버전은 안드로이드 빌드 문제로 "kotlinVersion"을 `1.9.0`으�
 | `zoneNumber`         |  ✓  |    ✓    |  `string` | 도로명 주소 우편번호. 배송지 타입이 NEW(도로명 주소)인 경우 반드시 존재함 |
 | `zipCode`         |  ✓  |    ✓    |  `string` | 지번 주소 우편번호. 배송지 타입이 OLD(지번 주소)여도 값이 없을 수 있음 |
 
+#### 서비스 약관 동의 내역 확인하기 -> `serviceTerms` => `KakaoServiceTerms`
+
+> [카카오싱크](https://developers.kakao.com/docs/latest/ko/kakaosync/common#intro)를 도입한 서비스만 사용할 수 있는 기능입니다.
+
+|                          | iOS | Android |    type    |  Description   |
+| ------------------------ | :-: | :-----: | :--------: | :------------: |
+| `userId`                 |  ✓  |    ✓    |  `string?`  | 사용자 Id |
+| `allowedServiceTerms`    |  ✓  |    ✓    |  `KakaoAllowedServiceTerms[]?`| 사용자가 동의한 3rd의 약관 목록 |
+| `appServiceTerms`        |  ✓  |    ✓    |  `KakaoAppServiceTerms[]?` |  앱에 사용 설정된 서비스 약관 목록  |
+
+##### 사용자가 동의한 서비스 약관 (KakaoAllowedServiceTerms)
+
+|                          | iOS | Android |    type    |  Description   |
+| ------------------------ | :-: | :-----: | :--------: | :------------: |
+| `tag`                    |  ✓  |    ✓    |  `string`  | 3rd에서 동의한 약관의 항목들을 정의한 값 |
+| `agreedAt`               |  ✓  |    ✓    |  `string`  | 동의한 시간. 약관이 여러번 뜨는 구조라면, 마지막으로 동의한 시간 |
+
+##### 앱에 사용 설정된 서비스 약관 (KakaoAppServiceTerms)
+
+|                          | iOS | Android |    type    |  Description   |
+| ------------------------ | :-: | :-----: | :--------: | :------------: |
+| `tag`                    |  ✓  |    ✓    |  `string`  | 3rd에서 동의한 약관의 항목들을 정의한 값 |
+| `createAt`               |  ✓  |    ✓    |  `string`  | 약관을 생성한 시간 |
+| `updatedAt`              |  ✓  |    ✓    |  `string`  | 약관을 수정한 시간 |
+
 #### React-native-web
 
 1.RestApiKey랑 redirectUrl을 포함한 아래 링크로 href 링크를 열어서 code를 가져옵니다
@@ -294,6 +319,12 @@ const getKakaoShippingAddresses = async (): Promise<void> => {
 
   setResult(JSON.stringify(addresses));
 };
+
+const getKakaoServiceTerms = async (): Promise<void> => {
+  const serviceTerms: KakaoServiceTerms = await serviceTerms();
+
+  setResult(JSON.stringify(serviceTerms))
+}
 
 const unlinkKakao = async (): Promise<void> => {
   const message = await unlink();

--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.kt
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.kt
@@ -265,6 +265,52 @@ class RNKakaoLoginsModule(private val reactContext: ReactApplicationContext) : R
         }
     }
 
+    @ReactMethod
+    private fun serviceTerms(promise: Promise) {
+        UserApiClient.instance.serviceTerms { userServiceTerms, error ->
+            if (error != null) {
+                promise.reject("RNKakaoLogins", error.message, error)
+                return@serviceTerms
+            }
+
+            if (userServiceTerms != null) {
+                val map = Arguments.createMap()
+
+                userServiceTerms.userId?.toDouble()?.let { userId ->
+                    map.putDouble("userId", userId)
+                }
+
+                val allowedServiceTerms = Arguments.createArray()
+                userServiceTerms.allowedServiceTerms?.map {
+                    Arguments.createMap().apply {
+                        putString("tag", it.tag)
+                        putString("agreedAt", dateFormat(it.agreedAt))
+                    }
+                }?.forEach(allowedServiceTerms::pushMap)
+                if (allowedServiceTerms.size() > 0) {
+                  map.putArray("allowedServiceTerms", allowedServiceTerms)
+                }
+
+                val appServiceTerms = Arguments.createArray()
+                userServiceTerms.appServiceTerms?.map {
+                    Arguments.createMap().apply {
+                        putString("tag", it.tag)
+                        putString("createdAt", dateFormat(it.createdAt))
+                        putString("updatedAt", dateFormat(it.updatedAt))
+                    }
+                }?.forEach(appServiceTerms::pushMap)
+                if (appServiceTerms.size() > 0) {
+                  map.putArray("appServiceTerms", appServiceTerms)
+                }
+
+                promise.resolve(map)
+                return@serviceTerms
+            }
+
+            promise.reject("RNKakaoLogins", "serviceTerms is null")
+        }
+    }
+
     companion object {
         private const val TAG = "RNKakaoLoginModule"
     }

--- a/ios/RNKakaoLogins/RNKakaoLogins.m
+++ b/ios/RNKakaoLogins/RNKakaoLogins.m
@@ -11,5 +11,6 @@ RCT_EXTERN_METHOD(unlink:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseR
 RCT_EXTERN_METHOD(getProfile:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
 RCT_EXTERN_METHOD(getAccessToken:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
 RCT_EXTERN_METHOD(shippingAddresses:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
+RCT_EXTERN_METHOD(serviceTerms:(RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject);
 
 @end

--- a/ios/RNKakaoLogins/RNKakaoLogins.swift
+++ b/ios/RNKakaoLogins/RNKakaoLogins.swift
@@ -234,4 +234,49 @@ class RNKakaoLogins: NSObject {
             }
         }
     }
+
+    @objc(serviceTerms:rejecter:)
+    func serviceTerms(_ resolve: @escaping RCTPromiseResolveBlock,
+                rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+        DispatchQueue.main.async {
+            UserApi.shared.serviceTerms {(userServiceTerms, error) in
+                if let error = error {
+                    reject("RNKakaoLogins", error.localizedDescription, nil)
+                }
+                else {
+                    let dateFormatter = DateFormatter()
+                    dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+                    var result: [String: Any] = [:]
+
+                    if let userId = userServiceTerms?.userId {
+                        result["userId"] = userId
+                    }
+
+                    if let allowedServiceTerms = userServiceTerms?.allowedServiceTerms {
+                        let formattedAllowedServiceTerms = allowedServiceTerms.map { serviceTerms in
+                            [
+                                "tag": serviceTerms.tag,
+                                "agreedAt": dateFormatter.string(from: serviceTerms.agreedAt)
+                            ]
+                        }
+                        result["allowedServiceTerms"] = formattedAllowedServiceTerms
+                    }
+
+                    if let appServiceTerms = userServiceTerms?.appServiceTerms {
+                        let formattedAppServiceTerms = appServiceTerms.map { appServiceTerms in
+                            [
+                                "tag": appServiceTerms.tag,
+                                "createdAt": dateFormatter.string(from: appServiceTerms.createdAt),
+                                "updatedAt": dateFormatter.string(from: appServiceTerms.updatedAt)
+                            ]
+                        }
+                        result["appServiceTerms"] = formattedAppServiceTerms
+                    }
+
+                    resolve(result)
+                }
+            }
+        }
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,7 @@ const NativeKakaoLogins: KakaoLoginModuleInterface = {
   },
   serviceTerms() {
     return RNKakaoLogins.serviceTerms();
-  
-  }
+  },
 };
 
 export const login = NativeKakaoLogins.login;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ const NativeKakaoLogins: KakaoLoginModuleInterface = {
   shippingAddresses() {
     return RNKakaoLogins.shippingAddresses();
   },
+  serviceTerms() {
+    return RNKakaoLogins.serviceTerms();
+  
+  }
 };
 
 export const login = NativeKakaoLogins.login;
@@ -34,5 +38,6 @@ export const unlink = NativeKakaoLogins.unlink;
 export const getProfile = NativeKakaoLogins.getProfile;
 export const getAccessToken = NativeKakaoLogins.getAccessToken;
 export const shippingAddresses = NativeKakaoLogins.shippingAddresses;
+export const serviceTerms = NativeKakaoLogins.serviceTerms;
 
 export * from './types';

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -63,6 +63,15 @@ const WebKakaoLogins: KakaoLoginModuleInterface = {
       },
     }).then((res) => res.json());
   },
+  serviceTerms(tokenWeb?: string) {
+    return fetch('https://kapi.kakao.com/v2/user/service_terms', {
+      method: 'get',
+      headers: {
+        Authorization: `Bearer ${tokenWeb}`,
+        'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+      },
+    }).then((res) => res.json());
+  },
   async getAccessToken() {
     throw new Error('Web does not support `getAccessToken`');
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,8 @@ export interface KakaoLoginModuleInterface {
   loginWithKakaoAccount(): Promise<KakaoOAuthToken>;
 
   shippingAddresses(): Promise<KakaoShippingAddresses>;
+
+  serviceTerms(): Promise<KakaoServiceTerms>;
 }
 
 export type KakaoOAuthToken = {
@@ -103,4 +105,21 @@ export type KakaoShippingAddress = {
   receiverPhoneNumber2: string;
   zoneNumber: string;
   zipCode: string;
+};
+
+export declare type KakaoAllowedServiceTerms = {
+  tag: string;
+  agreedAt: string;
+}
+
+export declare type KakaoAppServiceTerms = {
+  tag: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export declare type KakaoServiceTerms = {
+  userId?: number;
+  allowedServiceTerms?: KakaoAllowedServiceTerms[];
+  appServiceTerms?: KakaoAppServiceTerms[];
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -110,13 +110,13 @@ export type KakaoShippingAddress = {
 export declare type KakaoAllowedServiceTerms = {
   tag: string;
   agreedAt: string;
-}
+};
 
 export declare type KakaoAppServiceTerms = {
   tag: string;
   createdAt: string;
   updatedAt: string;
-}
+};
 
 export declare type KakaoServiceTerms = {
   userId?: number;


### PR DESCRIPTION
## 배경
[카카오 싱크](https://developers.kakao.com/docs/latest/ko/kakaosync/common#intro)를 이용하면 카카오 뿐만 아니라 서비스 약관 동의까지 한 번에 동의받을 수 있는 간편 가입 기능을 이용할 수 있습니다. 그리고 사용자가 동의한 서비스 약관에 대한 정보가 필요한 경우가 있기에 사용자가 동의한 서비스 약관을 조회할 수 있는 기능을 제공합니다.

## 관련 이슈
- #352
