### PR TITLE
fix: 서비스 약관 동의 목록 조회의 카카오 SDK v2 대응

### DIFF
--- a/KakaoLoginExample/src/pages/Intro.tsx
+++ b/KakaoLoginExample/src/pages/Intro.tsx
@@ -96,7 +96,7 @@ const Intro = () => {
       </Pressable>
       <Pressable
         style={styles.button}
-        onPress={() => getKakaoServiceTerms()}
+        onPress={() => getServiceTerms()}
       >
         <Text style={styles.text}>
           서비스 약관 동의 내역 확인

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Proguard Rule을 [공식 문서](https://developers.kakao.com/docs/latest/ko/and
 
 |                          | iOS | Android |    type    |  Description   |
 | ------------------------ | :-: | :-----: | :--------: | :------------: |
-| `userId`                 |  ✓  |    ✓    |  `number`  | 회원 번호 |
+| `userId`                 |  ✓  |    ✓    |  `number?`  | 회원 번호 |
 | `serviceTerms`           |  ✓  |    ✓    |  `KakaoServiceTerms[]?`| 조회한 서비스 약관 목록 |
 
 ##### 조회한 서비스 약관 목록 (KakaoServiceTerms)

--- a/README.md
+++ b/README.md
@@ -261,30 +261,24 @@ Proguard Rule을 [공식 문서](https://developers.kakao.com/docs/latest/ko/and
 | `zoneNumber`         |  ✓  |    ✓    |  `string` | 도로명 주소 우편번호. 배송지 타입이 NEW(도로명 주소)인 경우 반드시 존재함 |
 | `zipCode`         |  ✓  |    ✓    |  `string` | 지번 주소 우편번호. 배송지 타입이 OLD(지번 주소)여도 값이 없을 수 있음 |
 
-#### 서비스 약관 동의 내역 확인하기 -> `serviceTerms` => `KakaoServiceTerms`
+#### 서비스 약관 동의 내역 확인하기 -> `serviceTerms` => `KakaoUserServiceTerms`
 
 > [카카오싱크](https://developers.kakao.com/docs/latest/ko/kakaosync/common#intro)를 도입한 서비스만 사용할 수 있는 기능입니다.
 
 |                          | iOS | Android |    type    |  Description   |
 | ------------------------ | :-: | :-----: | :--------: | :------------: |
-| `userId`                 |  ✓  |    ✓    |  `string?`  | 사용자 Id |
-| `allowedServiceTerms`    |  ✓  |    ✓    |  `KakaoAllowedServiceTerms[]?`| 사용자가 동의한 3rd의 약관 목록 |
-| `appServiceTerms`        |  ✓  |    ✓    |  `KakaoAppServiceTerms[]?` |  앱에 사용 설정된 서비스 약관 목록  |
+| `userId`                 |  ✓  |    ✓    |  `number`  | 회원 번호 |
+| `serviceTerms`           |  ✓  |    ✓    |  `KakaoServiceTerms[]?`| 조회한 서비스 약관 목록 |
 
-##### 사용자가 동의한 서비스 약관 (KakaoAllowedServiceTerms)
-
-|                          | iOS | Android |    type    |  Description   |
-| ------------------------ | :-: | :-----: | :--------: | :------------: |
-| `tag`                    |  ✓  |    ✓    |  `string`  | 3rd에서 동의한 약관의 항목들을 정의한 값 |
-| `agreedAt`               |  ✓  |    ✓    |  `string`  | 동의한 시간. 약관이 여러번 뜨는 구조라면, 마지막으로 동의한 시간 |
-
-##### 앱에 사용 설정된 서비스 약관 (KakaoAppServiceTerms)
+##### 조회한 서비스 약관 목록 (KakaoServiceTerms)
 
 |                          | iOS | Android |    type    |  Description   |
 | ------------------------ | :-: | :-----: | :--------: | :------------: |
 | `tag`                    |  ✓  |    ✓    |  `string`  | 3rd에서 동의한 약관의 항목들을 정의한 값 |
-| `createAt`               |  ✓  |    ✓    |  `string`  | 약관을 생성한 시간 |
-| `updatedAt`              |  ✓  |    ✓    |  `string`  | 약관을 수정한 시간 |
+| `agreed`                 |  ✓  |    ✓    |  `boolean` | 동의 여부 |
+| `agreedAt`               |  ✓  |    ✓    |  `string?` | 최근 동의 시각 |
+| `required`               |  ✓  |    ✓    |  `boolean` | 필수 동의 여부 |
+| `revocable`              |  ✓  |    ✓    |  `boolean` | 철회 가능 여부 |
 
 #### React-native-web
 
@@ -339,7 +333,7 @@ const getKakaoShippingAddresses = async (): Promise<void> => {
 };
 
 const getKakaoServiceTerms = async (): Promise<void> => {
-  const serviceTerms: KakaoServiceTerms = await serviceTerms();
+  const serviceTerms: KakaoUserServiceTerms = await serviceTerms();
 
   setResult(JSON.stringify(serviceTerms))
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,7 @@ dependencies {
   def kakaoVersion = getExtOrDefault('kakaoSdkVersion')
   implementation "com.kakao.sdk:v2-user:$kakaoVersion" // 카카오 로그인
   implementation "com.kakao.sdk:v2-talk:$kakaoVersion" // 친구, 메시지(카카오톡)
-  implementation "com.kakao.sdk:v2-story:$kakaoVersion" // 카카오 스토리
+  implementation "com.kakao.sdk:v2-story:2.17.0" // 카카오 스토리(지원 중단으로 버전 고정)
 }
 
 rootProject.allprojects {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,5 +3,5 @@ RNKakaoLogins_compileSdkVersion=31
 RNKakaoLogins_targetSdkVersion=31
 RNKakaoLogins_gradleVersion=7.2.2
 RNKakaoLogins_kotlinVersion=1.7.10
-RNKakaoLogins_kakaoSdkVersion=2.11.2
+RNKakaoLogins_kakaoSdkVersion=2.20.1
 android.useAndroidX=true

--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.kt
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.kt
@@ -273,32 +273,29 @@ class RNKakaoLoginsModule(private val reactContext: ReactApplicationContext) : R
                 return@serviceTerms
             }
 
-            if (userServiceTerms != null) {
-                val map = Arguments.createMap()
+            val result = Arguments.createMap()
 
-                map.putDouble("userId", userServiceTerms.id.toDouble())
-
-                val serviceTerms = Arguments.createArray()
-                userServiceTerms.serviceTerms?.map {
-                    Arguments.createMap().apply {
-                        putString("tag", it.tag)
-                        putBoolean("agreed", it.agreed)
-                        putBoolean("required", it.required)
-                        putBoolean("revocable", it.revocable)
-                        it.agreedAt?.let { agreedAt ->
-                          putString("agreedAt", dateFormat(agreedAt))
-                        }
-                    }
-                }?.forEach(serviceTerms::pushMap)
-                if (serviceTerms.size() > 0) {
-                  map.putArray("serviceTerms", serviceTerms)
-                }
-
-                promise.resolve(map)
-                return@serviceTerms
+            userServiceTerms?.id?.let { userId ->
+                result.putDouble("userId", userId.toDouble())
             }
 
-            promise.reject("RNKakaoLogins", "serviceTerms is null")
+            val serviceTerms = Arguments.createArray()
+            userServiceTerms?.serviceTerms?.map {
+                Arguments.createMap().apply {
+                    putString("tag", it.tag)
+                    putBoolean("agreed", it.agreed)
+                    putBoolean("required", it.required)
+                    putBoolean("revocable", it.revocable)
+                    it.agreedAt?.let { agreedAt ->
+                      putString("agreedAt", dateFormat(agreedAt))
+                    }
+                }
+            }?.forEach(serviceTerms::pushMap)
+            if (serviceTerms.size() > 0) {
+                result.putArray("serviceTerms", serviceTerms)
+            }
+
+            promise.resolve(result)
         }
     }
 

--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.kt
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.kt
@@ -276,31 +276,22 @@ class RNKakaoLoginsModule(private val reactContext: ReactApplicationContext) : R
             if (userServiceTerms != null) {
                 val map = Arguments.createMap()
 
-                userServiceTerms.userId?.toDouble()?.let { userId ->
-                    map.putDouble("userId", userId)
-                }
+                map.putDouble("userId", userServiceTerms.id.toDouble())
 
-                val allowedServiceTerms = Arguments.createArray()
-                userServiceTerms.allowedServiceTerms?.map {
+                val serviceTerms = Arguments.createArray()
+                userServiceTerms.serviceTerms?.map {
                     Arguments.createMap().apply {
                         putString("tag", it.tag)
-                        putString("agreedAt", dateFormat(it.agreedAt))
+                        putBoolean("agreed", it.agreed)
+                        putBoolean("required", it.required)
+                        putBoolean("revocable", it.revocable)
+                        it.agreedAt?.let { agreedAt ->
+                          putString("agreedAt", dateFormat(agreedAt))
+                        }
                     }
-                }?.forEach(allowedServiceTerms::pushMap)
-                if (allowedServiceTerms.size() > 0) {
-                  map.putArray("allowedServiceTerms", allowedServiceTerms)
-                }
-
-                val appServiceTerms = Arguments.createArray()
-                userServiceTerms.appServiceTerms?.map {
-                    Arguments.createMap().apply {
-                        putString("tag", it.tag)
-                        putString("createdAt", dateFormat(it.createdAt))
-                        putString("updatedAt", dateFormat(it.updatedAt))
-                    }
-                }?.forEach(appServiceTerms::pushMap)
-                if (appServiceTerms.size() > 0) {
-                  map.putArray("appServiceTerms", appServiceTerms)
+                }?.forEach(serviceTerms::pushMap)
+                if (serviceTerms.size() > 0) {
+                  map.putArray("serviceTerms", serviceTerms)
                 }
 
                 promise.resolve(map)

--- a/ios/RNKakaoLogins/RNKakaoLogins.swift
+++ b/ios/RNKakaoLogins/RNKakaoLogins.swift
@@ -249,29 +249,23 @@ class RNKakaoLogins: NSObject {
 
                     var result: [String: Any] = [:]
 
-                    if let userId = userServiceTerms?.userId {
-                        result["userId"] = userId
-                    }
+                    result["userId"] = userServiceTerms.id
 
-                    if let allowedServiceTerms = userServiceTerms?.allowedServiceTerms {
-                        let formattedAllowedServiceTerms = allowedServiceTerms.map { serviceTerms in
-                            [
-                                "tag": serviceTerms.tag,
-                                "agreedAt": dateFormatter.string(from: serviceTerms.agreedAt)
+                    if let serviceTerms = userServiceTerms?.serviceTerms {
+                        result["serviceTerms"] = serviceTerms.map {
+                            var terms = [
+                                "tag": $0.tag,
+                                "agreed": $0.agreed,
+                                "required": $0.required,
+                                "revocable": $0.revocable
                             ]
-                        }
-                        result["allowedServiceTerms"] = formattedAllowedServiceTerms
-                    }
 
-                    if let appServiceTerms = userServiceTerms?.appServiceTerms {
-                        let formattedAppServiceTerms = appServiceTerms.map { appServiceTerms in
-                            [
-                                "tag": appServiceTerms.tag,
-                                "createdAt": dateFormatter.string(from: appServiceTerms.createdAt),
-                                "updatedAt": dateFormatter.string(from: appServiceTerms.updatedAt)
-                            ]
+                            if let agreedAt = $0.agreedAt {
+                                terms["agreedAt"] = dateFormatter.string(from: agreedAt)
+                            }
+
+                            return terms
                         }
-                        result["appServiceTerms"] = formattedAppServiceTerms
                     }
 
                     resolve(result)

--- a/ios/RNKakaoLogins/RNKakaoLogins.swift
+++ b/ios/RNKakaoLogins/RNKakaoLogins.swift
@@ -249,7 +249,9 @@ class RNKakaoLogins: NSObject {
 
                     var result: [String: Any] = [:]
 
-                    result["userId"] = userServiceTerms.id
+                    if let useId = userServiceTerms?.id {
+                        result["userId"] = useId
+                    }
 
                     if let serviceTerms = userServiceTerms?.serviceTerms {
                         result["serviceTerms"] = serviceTerms.map {

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -87,5 +87,6 @@ export const unlink = WebKakaoLogins.unlink;
 export const getProfile = WebKakaoLogins.getProfile;
 export const getAccessToken = WebKakaoLogins.getAccessToken;
 export const shippingAddresses = WebKakaoLogins.shippingAddresses;
+export const serviceTerms = WebKakaoLogins.serviceTerms;
 
 export * from './types';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,7 @@ export interface KakaoLoginModuleInterface {
 
   shippingAddresses(): Promise<KakaoShippingAddresses>;
 
-  serviceTerms(): Promise<KakaoServiceTerms>;
+  serviceTerms(): Promise<KakaoUserServiceTerms>;
 }
 
 export type KakaoOAuthToken = {
@@ -119,7 +119,14 @@ export declare type KakaoAppServiceTerms = {
 };
 
 export declare type KakaoServiceTerms = {
-  userId?: number;
-  allowedServiceTerms?: KakaoAllowedServiceTerms[];
-  appServiceTerms?: KakaoAppServiceTerms[];
+  agreed: string;
+  agreedAt?: string;
+  required: string;
+  revocable: string;
+  tag: string;
+};
+
+export declare type KakaoUserServiceTerms = {
+  userId: number;
+  serviceTerms?: KakaoServiceTerms[];
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -127,6 +127,6 @@ export declare type KakaoServiceTerms = {
 };
 
 export declare type KakaoUserServiceTerms = {
-  userId: number;
+  userId?: number;
   serviceTerms?: KakaoServiceTerms[];
 };


### PR DESCRIPTION
## 배경
#404 이 포함된 5.4.0 이 배포되어 테스트하는 과정에서 빌드가 에러가 나서 확인해보니 #401 에서 카카오 SDK 가 v2 로 가면서 인터페이스가 변경되어 반영된 코드에서 에러가 발생하고 있었습니다. 그래서 몇 가지 추가로 수정사항을 반영합니다.

## 수정 방안

### iOS

- SDK v2 의 인터페이스에 맞게 코드 수정

### Android

- SDK 버전을 2.11.2 에서 2.20.1 로 변경
- 스토리는 2.18.0 부터 지원이 중단되었기 때문에 버전을 2.17.0 으로 고정

## 테스트

일단, 수정 사항을 개발중인 앱에 적용하여 로그인과 해당 정보를 가져오는데 문제가 없음은 확인하였습니다. 

## 연관 링크
- https://developers.kakao.com/docs/latest/ko/android/download#changelog


